### PR TITLE
✨ Replace unmantained net-tools with iproute2

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -45,6 +45,7 @@ RUN \
         gcompat=1.1.0-r4 \
         git=2.54.0-r0 \
         htop=3.5.1-r1 \
+        iproute2=7.0.0-r0 \
         json-c=0.18-r1 \
         libltdl=2.6.0-r1 \
         libstdc++=15.2.0-r5 \
@@ -61,7 +62,6 @@ RUN \
         ncdu=1.22-r2 \
         ncurses=6.6_p20260516-r0 \
         neovim=0.12.2-r0 \
-        net-tools=2.10-r3 \
         nmap=7.99-r0 \
         nmap-ncat=7.99-r0 \
         openssh=10.3_p1-r0 \


### PR DESCRIPTION
# Proposed Changes

Replace unmantained net-tools with iproute2.

## Related Issues

Closes https://github.com/hassio-addons/app-ssh/issues/1091


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the networking utilities available in the SSH environment.
  * Added modern network inspection and configuration commands through `iproute2`.
  * Removed the legacy `net-tools` package to streamline the available command-line utilities.
  * Existing workflows remain focused on current networking tools while reducing redundant utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->