### PR TITLE
👷 Replace Repology with Alpine CDN datasource for package pins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,12 @@
   "labels": ["dependencies", "no-stale"],
   "commitMessagePrefix": "⬆️",
   "commitMessageTopic": "{{depName}}",
+  "customDatasources": {
+    "alpine": {
+      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/",
+      "format": "html"
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -35,8 +41,9 @@
         "\\s\\s(?<package>[a-z0-9][a-z0-9-_]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
       ],
       "versioningTemplate": "loose",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_24/{{package}}"
+      "datasourceTemplate": "custom.alpine",
+      "depNameTemplate": "alpine_3_24/{{package}}",
+      "extractVersionTemplate": "^{{{package}}}-(?<version>\\d.*)\\.apk$"
     }
   ],
   "packageRules": [
@@ -46,8 +53,30 @@
       "automerge": true
     },
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true
+    },
+    {
+      "description": "Packages that live in the Alpine community repository",
+      "matchDatasources": ["custom.alpine"],
+      "matchPackageNames": [
+        "alpine_3_24/alsa-plugins-pulse",
+        "alpine_3_24/awake",
+        "alpine_3_24/colordiff",
+        "alpine_3_24/docker",
+        "alpine_3_24/docker-bash-completion",
+        "alpine_3_24/docker-zsh-completion",
+        "alpine_3_24/mtr",
+        "alpine_3_24/neovim",
+        "alpine_3_24/pulseaudio-utils",
+        "alpine_3_24/sudo",
+        "alpine_3_24/ttyd",
+        "alpine_3_24/zsh-autosuggestions",
+        "alpine_3_24/zsh-syntax-highlighting"
+      ],
+      "registryUrls": [
+        "https://dl-cdn.alpinelinux.org/alpine/v3.24/community/x86_64/"
+      ]
     },
     {
       "groupName": "App base image",
@@ -71,19 +100,19 @@
     },
     {
       "groupName": "Docker",
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true,
       "matchPackageNames": ["/^alpine_.*/docker.*$/"]
     },
     {
       "groupName": "OpenSSL",
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true,
       "matchPackageNames": ["/^alpine_.*/openssl.*$/"]
     },
     {
       "groupName": "Python",
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true,
       "matchPackageNames": ["/^alpine_.*/python3(-dev)?$/"]
     }


### PR DESCRIPTION
# Proposed Changes

Renovate stopped updating our Alpine package pins. The Dependency Dashboard (#506) reports `Repology lookup failed with unexpected error`, with every single `alpine_3_24/*` package coming back as `no-result`. The last successful Alpine bump was #1115 on 17 Aug.

Repology rate limits its `tools/project-by` endpoint aggressively (I get a `403` on the second request within a second), and each Renovate run resolves around 60 packages through it. So this is not a config problem and not something that recovers reliably: it will keep happening, and it silently stops all Alpine pin updates until someone notices a broken build. It already broke CI here, `tmux` moved to `3.7c-r0` upstream while we still pin `3.6b-r0`, which fails the `apk add` in the Dockerfile.

This replaces Repology with a Renovate custom datasource that reads Alpine's own package index on `dl-cdn.alpinelinux.org`, which is the same place `apk` installs from. Renovate's `html` format turns each `href` in the directory listing (`tmux-3.7c-r0.apk`) into a version candidate, and `extractVersionTemplate` picks the version per package.

Notes on the change:

- Dependency names stay `alpine_3_24/<package>`, so PR titles, branch names and the existing Docker / OpenSSL / Python grouping rules are unchanged.
- Custom datasources use `registryStrategy: "first"` (multiple `registryUrls` are not hunted), so packages from the `community` repository need a rule pointing at the community index. That list is the one bit of new maintenance here. If a package moves repository it shows up as a lookup failure on the dashboard, the same way a Repology miss does today, so it fails loudly rather than silently.
- Two page fetches per run instead of roughly 60 API calls, and against a CDN built for package traffic.

Verified by running Renovate against this repository, `docker run ghcr.io/renovatebot/renovate:latest --platform=local --dry-run=lookup` (v44.33.2):

- all 61 Alpine pins resolve, no lookup failures, config validates cleanly
- exactly one update is found: `alpine_3_24/tmux 3.6b-r0 -> 3.7c-r0`, branch `renovate/alpine_3_24-tmux-3.x`
- that matches an independent diff of every pin against the v3.24 APKINDEX files, where `tmux` is also the only stale pin

Once this is merged Renovate should open (and automerge) the `tmux` bump on its own, which unblocks the build on `main` and on #1092.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency monitoring for Alpine Linux packages.
  * Improved version detection for Alpine repositories and community packages.
  * Refined dependency grouping for Docker, OpenSSL, and Python updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->