### PR TITLE
📝 Document connecting with Mosh

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ well. Additionally, it comes out of the box with the following:
   - Only uses known secure ciphers and algorithms.
   - Limits login attempts to hold off brute-force attacks better.
 - Comes with an SSH compatibility mode option to allow older clients to connect.
-- Support for Mosh allowing roaming and supports intermittent connectivity.
+- Support for [Mosh][mosh-docs] allowing roaming and supports intermittent
+  connectivity.
 - SFTP support is disabled by default but is user configurable.
 - Compatible if Home Assistant was installed via the generic Linux installer.
 - Username is configurable, so `root` is no longer mandatory.
@@ -151,6 +152,7 @@ SOFTWARE.
 [issue]: https://github.com/hassio-addons/app-ssh/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/app-ssh.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2026.svg
+[mosh-docs]: https://github.com/hassio-addons/app-ssh/blob/main/ssh/DOCS.md#connecting-with-mosh
 [ohmyzsh]: http://ohmyz.sh/
 [openssh]: https://www.openssh.com/
 [patreon-shield]: https://frenck.dev/wp-content/uploads/2019/12/patreon.png

--- a/ssh/.README.j2
+++ b/ssh/.README.j2
@@ -42,7 +42,8 @@ well. Additionally, it comes out of the box with the following:
   - Only uses known secure ciphers and algorithms.
   - Limits login attempts to hold off brute-force attacks better.
 - Comes with an SSH compatibility mode option to allow older clients to connect.
-- Support for Mosh allowing roaming and supports intermittent connectivity.
+- Support for [Mosh][mosh-docs] allowing roaming and supports intermittent
+  connectivity.
 - SFTP support is disabled by default but is user configurable.
 - Compatible if Home Assistant was installed via the generic Linux installer.
 - Username is configurable, so `root` is no longer mandatory.
@@ -107,6 +108,7 @@ If you are more interested in stable releases of our apps:
 [github-sponsors]: https://github.com/sponsors/frenck
 [hass-ssh]: https://home-assistant.io/addons/ssh/
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2026.svg
+[mosh-docs]: {{ repo }}/blob/main/ssh/DOCS.md#connecting-with-mosh
 [ohmyzsh]: http://ohmyz.sh/
 [openssh]: https://www.openssh.com/
 [patreon-shield]: https://frenck.dev/wp-content/uploads/2019/12/patreon.png

--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -29,7 +29,8 @@ well. Additionally, it comes out of the box with the following:
   - Only uses known secure ciphers and algorithms.
   - Limits login attempts to hold off brute-force attacks better.
 - Comes with an SSH compatibility mode option to allow older clients to connect.
-- Support for Mosh allowing roaming and supports intermittent connectivity.
+- Support for [Mosh](#connecting-with-mosh) allowing roaming and supports
+  intermittent connectivity.
 - SFTP support is disabled by default but is user configurable.
 - Compatible if Home Assistant was installed via the generic Linux installer.
 - Username is configurable, so `root` is no longer mandatory.

--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -241,6 +241,29 @@ Customize your shell environment even more with the `init_commands` option.
 Add one or more shell commands to the list, and they will be executed every
 single time this app starts.
 
+## Connecting with Mosh
+
+Next to OpenSSH, this app also ships with [Mosh][mosh]. Mosh is a remote
+terminal that survives suspending your machine, roaming between networks, and
+changing IP addresses. If you regularly close your laptop mid-session and want
+to pick it right back up, this is what you want.
+
+Mosh uses SSH for the initial login, so your existing configuration and keys
+keep working. Connect using the `mosh` command instead of `ssh`:
+
+```bash
+mosh root@homeassistant.local
+```
+
+Because this app runs on the host network, the UDP ports Mosh uses are
+available directly and require no additional configuration.
+
+Note that SSH connections are dropped after being unreachable for a while;
+this is intentional, as it cleans up connections that are no longer alive.
+Mosh is not affected by this. Combining Mosh with the
+[`share_sessions`](#option-share_sessions) option gives you a session that is
+durable on both ends.
+
 ## Clipboard: copying and pasting
 
 The Web Terminal is based on xterm.js, which follows X11-style clipboard
@@ -356,6 +379,7 @@ SOFTWARE.
 [github-ssh]: https://help.github.com/articles/connecting-to-github-with-ssh/
 [hass-ssh]: https://github.com/home-assistant/addons/tree/master/ssh
 [issue]: https://github.com/hassio-addons/app-ssh/issues
+[mosh]: https://mosh.org/
 [ohmyzsh]: http://ohmyz.sh/
 [openssh]: https://www.openssh.com/
 [reddit]: https://reddit.com/r/homeassistant


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Mosh has been advertised as a feature of this app for years, but was never documented beyond a single bullet point in the feature list. This came up in a discussion where a user was bothered by SSH sessions being dropped after their laptop went to sleep, and Mosh happens to be exactly the right answer for that use case.

Adds a "Connecting with Mosh" section to the docs, covering what Mosh is good for, how to connect with it, that it authenticates over SSH so existing keys keep working, that no extra port configuration is needed because the app runs on the host network, and how it relates to the SSH connection timeouts and the `share_sessions` option.

The feature list bullet now links to that new section, in the docs, the README, and the README template.

No functional changes, documentation only.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

https://github.com/hassio-addons/app-ssh/discussions/1122

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added links from the Mosh feature descriptions to dedicated documentation.
  * Documented how to connect with Mosh, including SSH-based authentication and required host-network UDP access.
  * Clarified Mosh connection behavior and compatibility with shared sessions.
  * Added supporting reference links in the main and SSH app documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->