### PR TITLE
🐛 Persist Bash shell history

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ well. Additionally, it comes out of the box with the following:
 - Compatible if Home Assistant was installed via the generic Linux installer.
 - Username is configurable, so `root` is no longer mandatory.
 - Persists custom SSH client settings & keys between app restarts
+- Persists the shell history of both ZSH and Bash between app restarts,
+  updates, and reboots.
 - Log levels for allowing you to triage issues easier.
 - Hardware access to your audio, uart/serial devices and GPIO pins.
 - Runs with more privileges, allowing you to debug and test more situations.

--- a/ssh/.README.j2
+++ b/ssh/.README.j2
@@ -48,6 +48,8 @@ well. Additionally, it comes out of the box with the following:
 - Compatible if Home Assistant was installed via the generic Linux installer.
 - Username is configurable, so `root` is no longer mandatory.
 - Persists custom SSH client settings & keys between app restarts
+- Persists the shell history of both ZSH and Bash between app restarts,
+  updates, and reboots.
 - Log levels for allowing you to triage issues easier.
 - Hardware access to your audio, uart/serial devices and GPIO pins.
 - Runs with more privileges, allowing you to debug and test more situations.

--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -35,6 +35,8 @@ well. Additionally, it comes out of the box with the following:
 - Compatible if Home Assistant was installed via the generic Linux installer.
 - Username is configurable, so `root` is no longer mandatory.
 - Persists custom SSH client settings & keys between app restarts
+- Persists the shell history of both ZSH and Bash between app restarts,
+  updates, and reboots.
 - Log levels for allowing you to triage issues easier.
 - Hardware access to your audio, uart/serial devices and GPIO pins.
 - Runs with more privileges, allowing you to debug and test more situations.

--- a/ssh/rootfs/etc/bash/history.sh
+++ b/ssh/rootfs/etc/bash/history.sh
@@ -1,0 +1,21 @@
+# shellcheck shell=bash
+# ==============================================================================
+# Home Assistant Community App: Advanced SSH & Web Terminal
+# Keeps the Bash shell history around
+# ==============================================================================
+
+# The history file itself is stored on persistent storage, however, Bash only
+# writes it out when a shell exits normally. Restarting or updating the app
+# kills all running shells, which would throw away everything typed during
+# those sessions. Appending after every command ensures the history hits the
+# disk right away.
+shopt -s histappend
+if [[ "${PROMPT_COMMAND}" != *"history -a"* ]]; then
+    PROMPT_COMMAND="history -a${PROMPT_COMMAND:+; ${PROMPT_COMMAND}}"
+fi
+
+# The Bash defaults only keep the last 500 commands around, which is easily
+# reached in a long running administrative shell. Match up with the amount
+# of history ZSH keeps in this app.
+HISTSIZE=50000
+HISTFILESIZE=10000

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
@@ -27,28 +27,30 @@ ln -s "/homeassistant" "/config" \
 ln -s "/homeassistant" "${HOME}/config" \
     || bashio::log.warning "Failed linking common directory: ${HOME}/config"
 
-# Sets up ZSH or Bash shell history
-if bashio::config.true "zsh"; then
-    touch "${ZSH_HISTORY_PERSISTENT_FILE}" \
-        || bashio::exit.nok 'Failed creating a persistent ZSH history file'
+# Sets up the shell history of both ZSH and Bash to be persistent.
+#
+# This is done regardless of the configured default shell; starting the other
+# shell from within a session is always possible, and its history should
+# survive an app restart or update just the same.
+touch "${ZSH_HISTORY_PERSISTENT_FILE}" \
+    || bashio::exit.nok 'Failed creating a persistent ZSH history file'
 
-    chmod 600 "${ZSH_HISTORY_PERSISTENT_FILE}" \
-        || bashio::exit.nok \
-            'Failed setting the correct permissions to the ZSH history file'
+chmod 600 "${ZSH_HISTORY_PERSISTENT_FILE}" \
+    || bashio::exit.nok \
+        'Failed setting the correct permissions to the ZSH history file'
 
-    ln -s -f "${ZSH_HISTORY_PERSISTENT_FILE}" "${ZSH_HISTORY_FILE}" \
-        || bashio::exit.nok 'Failed linking the persistent ZSH history file'
-else
-    touch "${BASH_HISTORY_PERSISTENT_FILE}" \
-        || bashio::exit.nok 'Failed creating a persistent Bash history file'
+ln -s -f "${ZSH_HISTORY_PERSISTENT_FILE}" "${ZSH_HISTORY_FILE}" \
+    || bashio::exit.nok 'Failed linking the persistent ZSH history file'
 
-    chmod 600 "${BASH_HISTORY_PERSISTENT_FILE}" \
-        || bashio::exit.nok \
-            'Failed setting the correct permissions to the Bash history file'
+touch "${BASH_HISTORY_PERSISTENT_FILE}" \
+    || bashio::exit.nok 'Failed creating a persistent Bash history file'
 
-    ln -s -f "${BASH_HISTORY_PERSISTENT_FILE}" "${BASH_HISTORY_FILE}" \
-        || bashio::exit.nok 'Failed linking the persistent Bash history file'
-fi
+chmod 600 "${BASH_HISTORY_PERSISTENT_FILE}" \
+    || bashio::exit.nok \
+        'Failed setting the correct permissions to the Bash history file'
+
+ln -s -f "${BASH_HISTORY_PERSISTENT_FILE}" "${BASH_HISTORY_FILE}" \
+    || bashio::exit.nok 'Failed linking the persistent Bash history file'
 
 # Set up Bash
 if ! bashio::config.true "zsh"; then


### PR DESCRIPTION
# Proposed Changes

Bash history was only linked into `/data` when the `zsh` option was set to `false`, so starting Bash from a ZSH session left it writing to a non-persistent `/root/.bash_history`. On top of that, Bash only writes its history file on a clean exit, so an app update replacing the container discarded everything typed in the running session.

Both history files are now linked into `/data` regardless of the configured default shell, and `/etc/bash/history.sh` makes Bash append to its history file after every command. It also raises `HISTSIZE`/`HISTFILESIZE` from the Bash default of 500 to the 50000/10000 that oh-my-zsh uses for ZSH.

`/etc/bash/` is sourced by `/etc/bash/bashrc` for interactive shells and, through `/etc/profile.d/00-bashrc.sh`, for login shells as well. That covers `bash -l` inside tmux, a bare `bash` typed from a ZSH session, and the `share_sessions: false` path that removes `/root/.bash_profile`.

Verified against the base image by SIGKILLing the shell mid-session: history is now on disk in all of the above cases, and was lost in every one of them before.

## Related Issues

Fixes #1126


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shell history for ZSH and Bash now persists across app restarts, updates, and system reboots.
  * Bash history is saved after each command, with expanded history capacity.
* **Documentation**
  * Updated product and SSH app documentation to describe persistent shell history support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->